### PR TITLE
fix: teardown not call after 'exit 1'

### DIFF
--- a/runTests.sh
+++ b/runTests.sh
@@ -185,7 +185,9 @@ checkHasTests() {
 
 runTest() {
   callIfExists setup
+  trap 'callIfExists teardown' EXIT # set a trap to call teardown in case an exception is thrown
   $1
+  trap - EXIT # Exited normally, so we can remove the trap
   callIfExists teardown
 }
 


### PR DESCRIPTION
To be able to use environment variables from the test functions, the
test functions are not called in a subshell, but if a test exists
prematurely, the test should exit, but the teardown should still be
called.
This broke because the test that should have catched this did not run as
it was overriden by another test with the same name. Stupid mistake.

The problem is solved by creating an exit trap.

fixes #7